### PR TITLE
Use `/J` option (default char type is unsigned)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_dependent_option(REMSVC_MSPDB "Enabled MS PDB 4.1 support" OFF "TARGET MSP
 cmake_dependent_option(REMSVC_RECCMP "Build accurate executables" OFF "MSVC" OFF)
 
 if(REMSVC_RECCMP)
-    set(CMAKE_C_FLAGS "/W2 /GX /D \"WIN32\" /D \"_WINDOWS\"")
+    set(CMAKE_C_FLAGS "/W2 /GX /J /D \"WIN32\" /D \"_WINDOWS\"")
     set(CMAKE_C_FLAGS_DEBUG "/Gm /Zi /Od /D \"_DEBUG\"")
     set(CMAKE_C_FLAGS_RELEASE "/D \"NDEBUG\"")
     set(CMAKE_C_FLAGS_RELWITHDEBINFO "/Zi /D \"NDEBUG\"")

--- a/frontend/compile.c
+++ b/frontend/compile.c
@@ -375,7 +375,7 @@ char *get_minrebuild_options(context_s *ctx)
                     if (_fullpath(buffer2, arg_value_ptr, 1024) == NULL) {
                         strcpy(buffer2, option->arg);
                     }
-                    _mbslwr((unsigned char *) buffer2);
+                    _mbslwr(buffer2);
                     arg_value_ptr = buffer2;
                 }
                 strqcpy(buffer1, arg_value_ptr);
@@ -390,7 +390,7 @@ char *get_minrebuild_options(context_s *ctx)
         char *incString = xnew(lenInclude + 6);
         strcpy(incString, "-inc=");
         strqcpy(&incString[5], ctx->include);
-        _mbslwr((unsigned char *) incString);
+        _mbslwr(incString);
         len += lenInclude + 6;
         argv[arg_i] = incString;
     }
@@ -619,7 +619,7 @@ int dopass(context_s *ctx)
         ptr_include = ctx->include;
         for (;;) {
             argc += 2;
-            ptr_include = (char *) _mbschr((unsigned char *) ptr_include, ';');
+            ptr_include = (char *) _mbschr(ptr_include, ';');
             if (ptr_include == NULL) {
                 break;
             }
@@ -658,12 +658,12 @@ int dopass(context_s *ctx)
         for (;;) {
             char *ptr_end;
 
-            ptr_end = (char *) _mbschr((unsigned char *) ptr_include, ';');
+            ptr_end = (char *) _mbschr(ptr_include, ';');
             if (ptr_end == NULL) {
                 break;
             }
             if (ptr_include != ptr_end) {
-                int pos_non_whitespace = (int) _mbsspn((unsigned char *) ptr_include, (unsigned char *) " \t");
+                int pos_non_whitespace = (int) _mbsspn(ptr_include, " \t");
                 if (pos_non_whitespace < ptr_end - ptr_include) {
                     *argv_ptr++ = &arg_ptr[1];
                     arg_ptr = append(&arg_ptr[1], "-I");
@@ -676,7 +676,7 @@ int dopass(context_s *ctx)
             }
             ptr_include = &ptr_end[1];
         }
-        pos_non_whitespace = _mbsspn((unsigned char *) ptr_include, (unsigned char *) " \t");
+        pos_non_whitespace = _mbsspn(ptr_include, " \t");
         if (pos_non_whitespace < strlen(ptr_include)) {
             *argv_ptr++ = &arg_ptr[1];
             arg_ptr = append(&arg_ptr[1], "-I");
@@ -978,7 +978,7 @@ char *replaca(char *buffer, const char *format, context_s *ctx)
                 break;
             case 'B':
                 basename(path_buffer, filepath);
-                _mbsupr((unsigned char *) path_buffer);
+                _mbsupr(path_buffer);
                 dest = concat(dest, path_buffer);
                 break;
             case 'e':

--- a/frontend/main.c
+++ b/frontend/main.c
@@ -1468,8 +1468,8 @@ BOOL early_switch_scan(char **argv, int argc)
                 if (fgets(line, sizeof(line) - 1, f) != NULL) {
                     char *pos_nologo = strstr(line, "nologo");
                     if (pos_nologo != NULL && pos_nologo > line && (pos_nologo[-1] == '-' || pos_nologo[-1] == '/') &&
-                        (pos_nologo == line + 1 || _mbschr((unsigned char *) " \t\"", pos_nologo[-2]) != NULL) &&
-                        (pos_nologo[6] == '\0' || _mbschr((unsigned char *) " \t\"\n", pos_nologo[6]))) {
+                        (pos_nologo == line + 1 || _mbschr(" \t\"", pos_nologo[-2]) != NULL) &&
+                        (pos_nologo[6] == '\0' || _mbschr(" \t\"\n", pos_nologo[6]))) {
                         found = TRUE;
                     }
                 }
@@ -1569,7 +1569,7 @@ void deactivate_passes(flag_s *option)
         passinfo_s *filetype_compiler_spec;
         for (filetype_compiler_spec = filetype_spec->passes; filetype_compiler_spec->pass_filename != NULL;
              filetype_compiler_spec++) {
-            if (a0 == '.' || _mbschr((unsigned char *) option->arg, filetype_compiler_spec->id) != NULL) {
+            if (a0 == '.' || _mbschr(option->arg, filetype_compiler_spec->id) != NULL) {
                 filetype_compiler_spec->is_active = 0;
             }
         }
@@ -1650,20 +1650,20 @@ void check_compile_collide(flag_s *option)
         const char *arg2;
         const char *end_arg2;
 
-        arg1_space = (char *) _mbschr((unsigned char *) option->arg, ' ');
-        arg2_space = (char *) _mbschr((unsigned char *) arg1_space + 1, ' ');
+        arg1_space = (char *) _mbschr(option->arg, ' ');
+        arg2_space = (char *) _mbschr(arg1_space + 1, ' ');
         *arg2_space = '\0';
         arg2 = arg2_space + 1;
         end_arg2 = arg2;
         for (;;) {
-            char *next_end_arg2 = (char *) _mbsinc((unsigned char *) end_arg2);
+            char *next_end_arg2 = (char *) _mbsinc(end_arg2);
             if (next_end_arg2 == NULL || *next_end_arg2 == '\0') {
                 break;
             }
             end_arg2 = next_end_arg2;
         }
-        if (_mbsstr((unsigned char *) arg2, (unsigned char *) "%b") == NULL &&
-            _mbschr((unsigned char *) "\\/", *end_arg2) == NULL) {
+        if (_mbsstr(arg2, "%b") == NULL &&
+            _mbschr("\\/", *end_arg2) == NULL) {
             cmderr(2036, &arg1_space[1], arg2);
         }
     }
@@ -1683,7 +1683,7 @@ void configure_asmlist(flag_s *option)
     if (option->arg[0] == '\0') {
         return;
     }
-    arg_extra = (char *) _mbschr((unsigned char *) option->arg, ' ');
+    arg_extra = (char *) _mbschr(option->arg, ' ');
     if (arg_extra != NULL) {
         *arg_extra = '\0';
         arg_extra += 1;
@@ -1830,7 +1830,7 @@ void check_required()
         parent_value = xstrdup(parent->required);
         parent_ptr = parent_value;
         while (1) {
-            char *next_ptr = (char *) _mbschr((unsigned char *) parent_ptr, ';');
+            char *next_ptr = (char *) _mbschr(parent_ptr, ';');
             flag_s *implied1;
             flag_s *implied2;
             flag_s *implied3;
@@ -1916,7 +1916,7 @@ const char *complete_filename(const char *extension_spec, char *path, const char
         path_ptr = concat(path, filename);
     } else {
         path_filename = path;
-        path_ptr = (char *) _mbsrchr((unsigned char *) path_filename, '.');
+        path_ptr = (char *) _mbsrchr(path_filename, '.');
         if (path_ptr == NULL) {
             path_ptr = &path[strlen(path)];
         } else if (ext_c1 != '<') {
@@ -1982,12 +1982,12 @@ int Dargs(const char **args, int *index)
     if (macro_arg == NULL || macro_arg[0] == '\0') {
         cmderr(2004, "D");
     }
-    pos_hash = (char *) _mbschr((unsigned char *) macro_arg, '#');
+    pos_hash = (char *) _mbschr(macro_arg, '#');
     if (pos_hash != NULL) {
         /* FIXME/BUG: this function modifies args ! */
         *pos_hash = '=';
     }
-    pos_assign = (char *) _mbschr((unsigned char *) macro_arg, '=');
+    pos_assign = (char *) _mbschr(macro_arg, '=');
     if (pos_assign == NULL) {
         macro_name_len = strlen(macro_arg);
     } else {

--- a/frontend/util.c
+++ b/frontend/util.c
@@ -46,7 +46,7 @@ char *pathname(char *buffer, const char *path)
 const char *gobblewhite(const char *text)
 {
     while (*text != '\0' && _ismbcspace(*text)) {
-        text = (char *) _mbsinc((unsigned char *) text);
+        text = (char *) _mbsinc(text);
     }
     return text;
 }
@@ -66,13 +66,13 @@ char *concatmeta(char *dest, const char *fmt)
     dest = dest + strlen(dest);
     if (fmt != NULL) {
         while (*fmt != '\0') {
-            _mbccpy((unsigned char *) dest, (unsigned char *) fmt);
-            dest = (char *) _mbsinc((unsigned char *) dest);
-            if (_mbsncmp((unsigned char *) fmt, (unsigned char *) "%", 1) == 0) {
-                _mbccpy((unsigned char *) dest, (unsigned char *) fmt);
-                dest = (char *) _mbsinc((unsigned char *) dest);
+            _mbccpy(dest, fmt);
+            dest = (char *) _mbsinc(dest);
+            if (_mbsncmp(fmt, "%", 1) == 0) {
+                _mbccpy(dest, fmt);
+                dest = (char *) _mbsinc(dest);
             }
-            fmt = (char *) _mbsinc((unsigned char *) fmt);
+            fmt = (char *) _mbsinc(fmt);
         }
         *dest = '\0';
     }
@@ -109,16 +109,16 @@ size_t strqlen(const char *path)
         if (_ismbcspace(*path)) {
             space = true;
         }
-        if (_mbsncmp((unsigned char *) path, (unsigned char *) "\"", 1) == 0) {
+        if (_mbsncmp(path, "\"", 1) == 0) {
             len += count_backslash + 1;
         }
-        if (_mbsncmp((unsigned char *) path, (unsigned char *) "\\", 1) == 0) {
+        if (_mbsncmp(path, "\\", 1) == 0) {
             count_backslash += 1;
         } else {
             count_backslash = 0;
         }
-        len += _mbclen((unsigned char *) path);
-        path = (char *) _mbsinc((unsigned char *) path);
+        len += _mbclen(path);
+        path = (char *) _mbsinc(path);
     }
     if (space) {
         len += count_backslash + 2;
@@ -136,32 +136,32 @@ char *strqcpy(char *dest, const char *path)
         if (_ismbcspace(*path)) {
             space = true;
         }
-        if (_mbsncmp((unsigned char *) path, (unsigned char *) "\"", 1) == 0) {
+        if (_mbsncmp(path, "\"", 1) == 0) {
             while (count_backslash-- >= 0) {
-                _mbccpy((unsigned char *) write_ptr, (unsigned char *) "\\");
-                write_ptr = (char *) _mbsinc((unsigned char *) write_ptr);
+                _mbccpy(write_ptr, "\\");
+                write_ptr = (char *) _mbsinc(write_ptr);
             }
         }
-        if (_mbsncmp((unsigned char *) path, (unsigned char *) "\\", 1) == 0) {
+        if (_mbsncmp(path, "\\", 1) == 0) {
             count_backslash += 1;
         } else {
             count_backslash = 0;
         }
-        _mbccpy((unsigned char *) write_ptr, (unsigned char *) path);
-        write_ptr = (char *) _mbsinc((unsigned char *) write_ptr);
-        path = (char *) _mbsinc((unsigned char *) path);
+        _mbccpy(write_ptr, path);
+        write_ptr = (char *) _mbsinc(write_ptr);
+        path = (char *) _mbsinc(path);
     }
     if (space) {
         memmove(&dest[1], dest, write_ptr - dest);
-        _mbccpy((unsigned char *) dest, (unsigned char *) "\"");
-        write_ptr = (char *) _mbsinc((unsigned char *) write_ptr);
+        _mbccpy(dest, "\"");
+        write_ptr = (char *) _mbsinc(write_ptr);
         while (count_backslash > 0) {
-            _mbccpy((unsigned char *) write_ptr, (unsigned char *) "\\");
-            write_ptr = (char *) _mbsinc((unsigned char *) write_ptr);
+            _mbccpy(write_ptr, "\\");
+            write_ptr = (char *) _mbsinc(write_ptr);
             count_backslash -= 1;
         }
-        _mbccpy((unsigned char *) write_ptr, (unsigned char *) "\"");
-        write_ptr = (char *) _mbsinc((unsigned char *) write_ptr);
+        _mbccpy(write_ptr, "\"");
+        write_ptr = (char *) _mbsinc(write_ptr);
     }
     *write_ptr = '\0';
     return dest;
@@ -173,13 +173,13 @@ const char *strrchars(const char *text, const char *needles)
     const char *last_pos = NULL;
 
     while (*needles != '\0') {
-        const char *pos = (char *) _mbsrchr((unsigned char *) text, *needles);
+        const char *pos = (char *) _mbsrchr(text, *needles);
         if (pos != NULL) {
             if (last_pos == NULL || last_pos < pos) {
                 last_pos = pos;
             }
         }
-        needles = (char *) _mbsinc((unsigned char *) needles);
+        needles = (char *) _mbsinc(needles);
     }
     return last_pos;
 }
@@ -211,15 +211,15 @@ char **sztoszv(const char *text, BOOL cleanUpSlash)
             bool copy_src = true;
             int nb_quotes = 0;
             int count_slash = 0;
-            while (_mbsncmp((unsigned char *) src_ptr, (unsigned char *) "\\", 1) == 0) {
-                src_ptr = (char *) _mbsinc((unsigned char *) src_ptr);
+            while (_mbsncmp(src_ptr, "\\", 1) == 0) {
+                src_ptr = (char *) _mbsinc(src_ptr);
                 count_slash += 1;
             }
-            if (_mbsncmp((unsigned char *) src_ptr, (unsigned char *) "\"", 1) == 0) {
+            if (_mbsncmp(src_ptr, "\"", 1) == 0) {
                 if (count_slash % 2 == 0) {
                     if (in_quotes) {
-                        if (_mbsncmp(_mbsinc((unsigned char *) src_ptr), (unsigned char *) "\"", 1) == 0) {
-                            src_ptr = (char *) _mbsinc((unsigned char *) src_ptr);
+                        if (_mbsncmp(_mbsinc(src_ptr), "\"", 1) == 0) {
+                            src_ptr = (char *) _mbsinc(src_ptr);
                             if (!cleanUpSlash) {
                                 nb_quotes = 1;
                             }
@@ -237,22 +237,22 @@ char **sztoszv(const char *text, BOOL cleanUpSlash)
             }
             while (count_slash != 0) {
                 count_slash -= 1;
-                _mbccpy((unsigned char *) dst_ptr, (unsigned char *) "\\");
-                dst_ptr = (char *) _mbsinc((unsigned char *) dst_ptr);
+                _mbccpy(dst_ptr, "\\");
+                dst_ptr = (char *) _mbsinc(dst_ptr);
             }
             while (nb_quotes != 0) {
                 nb_quotes -= 1;
-                _mbccpy((unsigned char *) dst_ptr, (unsigned char *) "\"");
-                dst_ptr = (char *) _mbsinc((unsigned char *) dst_ptr);
+                _mbccpy(dst_ptr, "\"");
+                dst_ptr = (char *) _mbsinc(dst_ptr);
             }
             if (src_ptr[0] == '\0' || (!in_quotes && _ismbcspace(src_ptr[0]))) {
                 break;
             }
             if (copy_src) {
-                _mbccpy((unsigned char *) dst_ptr, (unsigned char *) src_ptr);
-                dst_ptr = (char *) _mbsinc((unsigned char *) dst_ptr);
+                _mbccpy(dst_ptr, src_ptr);
+                dst_ptr = (char *) _mbsinc(dst_ptr);
             }
-            src_ptr = (char *) _mbsinc((unsigned char *) src_ptr);
+            src_ptr = (char *) _mbsinc(src_ptr);
         }
         dst_ptr[0] = '\0';
         dst_ptr += 1;
@@ -350,17 +350,17 @@ size_t l2a(unsigned long number, char *dest, int radix)
     str = &buffer[1];
     len = 0;
     while (1) {
-        _mbccpy((unsigned char *) str, (unsigned char *) &"0123456789abcdef"[number % radix]);
-        str = (char *) _mbsinc((unsigned char *) str);
+        _mbccpy(str, &"0123456789abcdef"[number % radix]);
+        str = (char *) _mbsinc(str);
         number /= radix;
         if (number == 0) {
             break;
         }
     }
     while (1) {
-        str = (char *) _mbsdec((unsigned char *) buffer, (unsigned char *) str);
-        _mbccpy((unsigned char *) dest, (unsigned char *) str);
-        dest = (char *) _mbsinc((unsigned char *) dest);
+        str = (char *) _mbsdec(buffer, str);
+        _mbccpy(dest, str);
+        dest = (char *) _mbsinc(dest);
         if (*str == '\0') {
             break;
         }
@@ -388,17 +388,17 @@ char *format(size_t *len, const char *fmt, va_list ap)
     char *write_ptr = buffer;
     const char *src;
     while (*fmt != '\0') {
-        if (_mbsncmp((unsigned char *) fmt, (unsigned char *) "%", 1) == 0) {
-            fmt = _mbsinc((unsigned char *) fmt);
+        if (_mbsncmp(fmt, "%", 1) == 0) {
+            fmt = _mbsinc(fmt);
             switch (*fmt) {
             case 'c':
                 *write_ptr = (char) va_arg(ap, int);
-                write_ptr = (char *) _mbsinc((unsigned char *) write_ptr);
+                write_ptr = (char *) _mbsinc(write_ptr);
                 break;
             case 'd':
             case 'x':
                 write_ptr += l2a(va_arg(ap, int), write_ptr,
-                _mbsncmp((unsigned char *) fmt, (unsigned char *) "d", 1) == 0 ? 10 : 0);
+                _mbsncmp(fmt, "d", 1) == 0 ? 10 : 0);
                 break;
             case 's':
                 src = va_arg(ap, const char *);
@@ -406,16 +406,16 @@ char *format(size_t *len, const char *fmt, va_list ap)
                 write_ptr += strlen(src);
                 break;
             default:
-                _mbccpy((unsigned char *) write_ptr, (unsigned char *) "%");
-                _mbccpy(_mbsinc((unsigned char *) write_ptr), (unsigned char *) fmt);
-                write_ptr = (char *) _mbsinc((unsigned char *) write_ptr);
+                _mbccpy(write_ptr, "%");
+                _mbccpy(_mbsinc(write_ptr), fmt);
+                write_ptr = (char *) _mbsinc(write_ptr);
                 break;
             }
         } else {
-            _mbccpy((unsigned char *) write_ptr, (unsigned char *) fmt);
-            write_ptr = (char *) _mbsinc((unsigned char *) write_ptr);
+            _mbccpy(write_ptr, fmt);
+            write_ptr = (char *) _mbsinc(write_ptr);
         }
-        fmt = _mbsinc((unsigned char *) fmt);
+        fmt = _mbsinc(fmt);
     }
     *write_ptr = '\0';
     *len = write_ptr - buffer;
@@ -522,9 +522,9 @@ const char *GetMessageInFile(const char *path, int code)
     start_text = gobblewhite(ptr_text) + 1;
     ptr_text = (char *) start_text; /* Skip first '"' */
 
-    while (_mbsncmp((unsigned char *) ptr_text, (unsigned char *) "\"", 1) != 0) {
-        if (_mbsncmp((unsigned char *) ptr_text, (unsigned char *) "\\", 1) == 0) {
-            switch (*_mbsinc((unsigned char *) ptr_text)) {
+    while (_mbsncmp(ptr_text, "\"", 1) != 0) {
+        if (_mbsncmp(ptr_text, "\\", 1) == 0) {
+            switch (*_mbsinc(ptr_text)) {
                 case 'n':
                     *ptr_text = '\n';
                     strcpy(ptr_text + 1, ptr_text + 2);
@@ -535,7 +535,7 @@ const char *GetMessageInFile(const char *path, int code)
                     break;
             }
         }
-        ptr_text = (char *) _mbsinc((unsigned char *) ptr_text);
+        ptr_text = (char *) _mbsinc(ptr_text);
     }
     *ptr_text = '\0';
     fclose(f);


### PR DESCRIPTION
I also removed all the casts to `(unsigned char *)`. This results in:
```
Increased (18):
0x4010e8 - flag_this_pass (72.73% -> 100.00%)
0x401226 - domatch (57.31% -> 58.45%)
0x4015d3 - expand (89.47% -> 90.35%)
0x4017ff - main (75.90% -> 76.20%)
0x40222b - crack_combo (65.66% -> 67.17%)
0x4023c4 - early_switch_scan (77.78% -> 79.80%)
0x402808 - check_compile_collide (79.65% -> 81.42%)
0x4028a3 - configure_asmlist (51.85% -> 52.53%)
0x4040c9 - dopass (89.31% -> 90.27%)
0x4045d8 - OmfResponseFile (51.80% -> 52.70%)
0x404897 - CoffResponseFile (93.55% -> 97.42%)
0x404d26 - replaca_strlen (80.79% -> 81.77%)
0x404efe - gobblewhite (94.74% -> 100.00%)
0x405039 - strqlen (72.38% -> 74.29%)
0x4050c0 - strqcpy (83.41% -> 84.30%)
0x405246 - sztoszv (44.61% -> 45.11%)
0x405672 - format (61.39% -> 62.38%)
0x405916 - GetMessageInFile (70.00% -> 72.50%)
```